### PR TITLE
Fix for finding all "float" states for settings.KEEP_MAX_CVL

### DIFF
--- a/aggregatebatteries.py
+++ b/aggregatebatteries.py
@@ -889,7 +889,7 @@ class DbusAggBatService(object):
 
         # find max. charge voltage (if needed)
         if not settings.OWN_CHARGE_PARAMETERS:
-            if settings.KEEP_MAX_CVL and ("Float" in ChargeMode_list):
+            if settings.KEEP_MAX_CVL and any("Float" in item for item in ChargeMode_list):
                 MaxChargeVoltage = self._fn._max(MaxChargeVoltage_list)
                     
             else:


### PR DESCRIPTION
The serial battery driver provides the float values with postfixes, e.g. "Float (linear ..)". The previous code did not catch these states. The new code will accept entries, that contain "float" but also additional text.